### PR TITLE
Fix stdatomic.h compilation error on GCC 5

### DIFF
--- a/pyqtdeploy/builder/builder.py
+++ b/pyqtdeploy/builder/builder.py
@@ -663,9 +663,10 @@ class Builder():
         self._write_main(build_dir, used_inittab)
         self._copy_lib_file('pyqtdeploy_start.cpp', build_dir)
         self._copy_lib_file('pdytools_module.cpp', build_dir)
+        self._copy_lib_file('pyqtdeploy_python.h', build_dir)
 
         defines = []
-        headers = ['pyqtdeploy_version.h', 'frozen_bootstrap.h']
+        headers = ['pyqtdeploy_version.h', 'frozen_bootstrap.h', 'pyqtdeploy_python.h']
 
         if py_version >= 0x030500:
             headers.append('frozen_bootstrap_external.h')
@@ -1081,7 +1082,7 @@ class Builder():
 
         f = self._create_file(build_dir + '/pyqtdeploy_main.cpp')
 
-        f.write('''#include <Python.h>
+        f.write('''#include "pyqtdeploy_python.h"
 #include <QtGlobal>
 
 ''')

--- a/pyqtdeploy/builder/lib/pdytools_module.cpp
+++ b/pyqtdeploy/builder/lib/pdytools_module.cpp
@@ -24,7 +24,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <Python.h>
+#include "pyqtdeploy_python.h"
+
 #include <marshal.h>
 #include <structmember.h>
 

--- a/pyqtdeploy/builder/lib/pyqtdeploy_python.h
+++ b/pyqtdeploy/builder/lib/pyqtdeploy_python.h
@@ -1,0 +1,6 @@
+#include <pyconfig.h>
+#if defined(__GNUG__) && defined(HAVE_STD_ATOMIC)
+#undef HAVE_STD_ATOMIC
+#endif
+
+#include <Python.h>

--- a/pyqtdeploy/builder/lib/pyqtdeploy_start.cpp
+++ b/pyqtdeploy/builder/lib/pyqtdeploy_start.cpp
@@ -26,7 +26,7 @@
 
 #include <stdio.h>
 
-#include <Python.h>
+#include "pyqtdeploy_python.h"
 
 #include <QByteArray>
 #include <QDir>


### PR DESCRIPTION
Because Py_BUILD_CORE is defined, Python.h includes private Python
headers, pyatomic.h is one of them.

pyatomic.h includes stdint.h, which isn't compatible with GCC 5 C++
compiler.

Fix the problem by undefining HAVE_STD_ATOMIC for GCC (pyatomic.h
switches to GCC built-in atomic functions in this case).

stdatomic.h is incompatible with C++ since its first appearance, so
there's no reason to do version check.
